### PR TITLE
Explicitly require devise

### DIFF
--- a/lib/devise/async.rb
+++ b/lib/devise/async.rb
@@ -1,3 +1,4 @@
+require "devise"
 require "active_support/dependencies"
 require "devise/async/version"
 


### PR DESCRIPTION
The call to `Devise.add_module` here will fail unless `devise` has already been required before requiring `devise-async`. In a rails app, the practical implication of this is that `devise` must be explicitly listed in the gemfile before `devise-async` even though `devise-async` depends on `devise` explicitly.